### PR TITLE
Remove "Xms_final" containers - switch to a `runmode` for the project

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,14 +140,15 @@ jobs:
       timeoutInMinutes: 40
 
     - script: |
-        cd tests/fixtures/complete; derex build-themes; ddc-project up -d lms_final cms_final
+        derex runmode production
+        cd tests/fixtures/complete; derex build-themes; ddc-project up -d lms cms
         sleep 5  # Give it time to start up
-      displayName: 'Start final image lms/cms'
+      displayName: 'Start production image lms/cms'
 
     - script: |
         cd tests/fixtures/complete
         ddc-project config
-        ddc-project logs cms_final lms_final
+        ddc-project logs cms lms
       condition: always()
       displayName: 'Show CMS/LMS final logs'
 

--- a/derex/runner/build.py
+++ b/derex/runner/build.py
@@ -61,6 +61,7 @@ def build_themes_image(project: Project):
         "COPY --from=static /openedx/staticfiles /openedx/staticfiles",
         "COPY themes/ /openedx/themes/",
         "COPY --from=static /openedx/edx-platform/common/static /openedx/edx-platform/common/static",
+        "COPY --from=static /openedx/empty_dump.sql.bz2 /openedx/",
         # It would be nice to run the following here, but docker immediately commits a layer after COPY,
         # so the files we'd like to remove are already final.
         # rmlint -g -c sh:symlink -o json:stderr /openedx/ 2> /dev/null && sed "/# empty /d" -i rmlint.sh && ./rmlint.sh -d > /dev/null

--- a/derex/runner/cli.py
+++ b/derex/runner/cli.py
@@ -40,7 +40,9 @@ def derex(ctx):
     from derex.runner.project import Project
 
     # Set up a StreamHandler
-    logging.getLogger().addHandler(logging.StreamHandler())
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.WARN)
+    logging.getLogger("derex").addHandler(handler)
 
     try:
         ctx.obj = Project()

--- a/derex/runner/cli.py
+++ b/derex/runner/cli.py
@@ -39,6 +39,9 @@ def derex(ctx):
     # Optimize --help and bash completion by importing
     from derex.runner.project import Project
 
+    # Set up a StreamHandler
+    logging.getLogger().addHandler(logging.StreamHandler())
+
     try:
         ctx.obj = Project()
     except ValueError:

--- a/derex/runner/cli.py
+++ b/derex/runner/cli.py
@@ -208,4 +208,13 @@ def runmode(project: Project, runmode: Optional[ProjectRunMode]):
     if runmode is None:
         click.echo(project.runmode.name)
     else:
-        project.runmode = runmode
+        if project.runmode == runmode:
+            click.echo(
+                f"The current project runmode is already {runmode.name}", err=True
+            )
+        else:
+            previous_runmode = project.runmode
+            project.runmode = runmode
+            click.echo(
+                f"Switched runmode: {previous_runmode.name} → {runmode.name}", err=True
+            )

--- a/derex/runner/cli.py
+++ b/derex/runner/cli.py
@@ -5,6 +5,7 @@ from click_plugins import with_plugins
 from derex.runner.project import Project
 from derex.runner.project import ProjectRunMode
 from functools import wraps
+from typing import Optional
 
 import click
 import importlib_metadata
@@ -202,7 +203,7 @@ def build_final_refresh(ctx, project: Project):
 )
 @click.pass_obj
 @ensure_project
-def runmode(project: Project, runmode: ProjectRunMode):
+def runmode(project: Project, runmode: Optional[ProjectRunMode]):
     """Get/set project runmode (debug/production)"""
     if runmode is None:
         click.echo(project.runmode.name)

--- a/derex/runner/cli.py
+++ b/derex/runner/cli.py
@@ -2,6 +2,8 @@
 
 """Console script for derex.runner."""
 from click_plugins import with_plugins
+from derex.runner.project import Project
+from derex.runner.project import ProjectRunMode
 from functools import wraps
 
 import click
@@ -152,7 +154,7 @@ def build_requirements(project):
 @click.pass_obj
 @click.pass_context
 @ensure_project
-def build_themes(ctx, project):
+def build_themes(ctx, project: Project):
     """Build the image that includes compiled themes"""
     from derex.runner.build import build_themes_image
 
@@ -168,7 +170,7 @@ def build_themes(ctx, project):
 @click.pass_obj
 @click.pass_context
 @ensure_project
-def build_final(ctx, project):
+def build_final(ctx, project: Project):
     """Build the final image for this project.
     For now this is the same as the final image"""
     ctx.forward(build_themes)
@@ -178,9 +180,26 @@ def build_final(ctx, project):
 @click.pass_obj
 @click.pass_context
 @ensure_project
-def build_final_refresh(ctx, project):
+def build_final_refresh(ctx, project: Project):
     """Also pull base docker image before starting building"""
     from derex.runner.docker import pull_images
 
     pull_images([project.base_image, project.final_base_image])
     ctx.forward(build_final)
+
+
+@derex.command()
+@click.argument(
+    "runmode",
+    type=click.Choice(ProjectRunMode.__members__),
+    required=False,
+    callback=lambda _, __, value: value and ProjectRunMode[value],
+)
+@click.pass_obj
+@ensure_project
+def runmode(project: Project, runmode: ProjectRunMode):
+    """Get/set project runmode (debug/production)"""
+    if runmode is None:
+        click.echo(project.runmode.name)
+    else:
+        project.runmode = runmode

--- a/derex/runner/config.py
+++ b/derex/runner/config.py
@@ -51,6 +51,10 @@ class LocalOpenEdX:
 
 
 def generate_local_docker_compose(project: Project) -> Path:
+    """This function is called every time ddc-project is run.
+    It assembles a docker-compose file from the given configuration.
+    It should execute as fast as possible.
+    """
     derex_dir = project.root / ".derex"
     if not derex_dir.is_dir():
         derex_dir.mkdir()

--- a/derex/runner/config.py
+++ b/derex/runner/config.py
@@ -1,5 +1,6 @@
 from derex.runner import hookimpl
 from derex.runner.build import build_requirements_image
+from derex.runner.project import DEREX_RUNNER_PROJECT_DIR
 from derex.runner.project import Project
 from derex.runner.utils import asbool
 from derex.runner.utils import compose_path
@@ -55,7 +56,7 @@ def generate_local_docker_compose(project: Project) -> Path:
     It assembles a docker-compose file from the given configuration.
     It should execute as fast as possible.
     """
-    derex_dir = project.root / ".derex"
+    derex_dir = project.root / DEREX_RUNNER_PROJECT_DIR
     if not derex_dir.is_dir():
         derex_dir.mkdir()
     local_compose_path = derex_dir / "docker-compose.yml"

--- a/derex/runner/project.py
+++ b/derex/runner/project.py
@@ -1,6 +1,7 @@
 from derex.runner.utils import CONF_FILENAME
 from derex.runner.utils import get_dir_hash
 from enum import Enum
+from logging import getLogger
 from pathlib import Path
 from typing import Optional
 from typing import Union
@@ -10,8 +11,11 @@ import os
 import yaml
 
 
+logger = getLogger(__name__)
+
+
 class ProjectRunMode(Enum):
-    debug = "debug"
+    debug = "debug"  # The first is the default
     production = "production"
 
 
@@ -57,8 +61,56 @@ class Project:
     # Path to a local docker-compose.yml file, if present
     local_compose: Optional[Path] = None
 
-    # Server http of choice and debug
-    runmode: ProjectRunMode = ProjectRunMode.debug
+    @property
+    def runmode(self) -> ProjectRunMode:
+        """The run mode of this project, either debug or production.
+        In debug mode django's runserver is used. Templates are reloaded
+        on every request and assets do not need to be collected.
+        In production mode gunicorn is run, and assets need to be compiled and collected.
+        """
+        name = "runmode"
+        mode_str = self._get_status(name)
+        if mode_str is not None:
+            if mode_str in ProjectRunMode.__members__:
+                return ProjectRunMode[mode_str]
+            # We found a string but we don't recognize it: warn the user
+            logger.warn(
+                f"Value `{mode_str}` found in `{self._status_filepath(name)}` "
+                "is not valid for runmode "
+                "(valid values are `debug` and `production`)"
+            )
+        default = self.config.get(f"default_{name}")
+        if default not in ProjectRunMode.__members__:
+            logger.warn(
+                f"Value `{default}` found in config `{self.root / CONF_FILENAME}` "
+                "is not a valid default for runmode "
+                "(valid values are `debug` and `production`)"
+            )
+        else:
+            return ProjectRunMode[default]
+        return next(iter(ProjectRunMode))  # Return the first by default
+
+    @runmode.setter
+    def runmode(self, value: ProjectRunMode):
+        self._set_status("runmode", value.name)
+
+    def _get_status(self, name: str) -> Optional[str]:
+        """Read value for the desired status from the project directory.
+        """
+        filepath = self._status_filepath(name)
+        if filepath.exists():
+            return filepath.read_text()
+        return None
+
+    def _set_status(self, name: str, value: str):
+        """Persist a status in the project directory
+        """
+        self._status_filepath(name).write_text(value)
+
+    def _status_filepath(self, name: str) -> Path:
+        """Return the full file path where a status for the project should be stored
+        """
+        return self.root / name
 
     def __init__(self, path: Union[Path, str] = None):
         if not path:

--- a/derex/runner/project.py
+++ b/derex/runner/project.py
@@ -80,14 +80,15 @@ class Project:
                 "(valid values are `debug` and `production`)"
             )
         default = self.config.get(f"default_{name}")
-        if default not in ProjectRunMode.__members__:
-            logger.warn(
-                f"Value `{default}` found in config `{self.root / CONF_FILENAME}` "
-                "is not a valid default for runmode "
-                "(valid values are `debug` and `production`)"
-            )
-        else:
-            return ProjectRunMode[default]
+        if default:
+            if default not in ProjectRunMode.__members__:
+                logger.warn(
+                    f"Value `{default}` found in config `{self.root / CONF_FILENAME}` "
+                    "is not a valid default for runmode "
+                    "(valid values are `debug` and `production`)"
+                )
+            else:
+                return ProjectRunMode[default]
         return next(iter(ProjectRunMode))  # Return the first by default
 
     @runmode.setter

--- a/derex/runner/project.py
+++ b/derex/runner/project.py
@@ -1,5 +1,6 @@
 from derex.runner.utils import CONF_FILENAME
 from derex.runner.utils import get_dir_hash
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 from typing import Union
@@ -7,6 +8,11 @@ from typing import Union
 import hashlib
 import os
 import yaml
+
+
+class ProjectRunMode(Enum):
+    debug = "debug"
+    production = "production"
 
 
 class Project:
@@ -50,6 +56,9 @@ class Project:
 
     # Path to a local docker-compose.yml file, if present
     local_compose: Optional[Path] = None
+
+    # Server http of choice and debug
+    runmode: ProjectRunMode = ProjectRunMode.debug
 
     def __init__(self, path: Union[Path, str] = None):
         if not path:

--- a/derex/runner/project.py
+++ b/derex/runner/project.py
@@ -12,6 +12,7 @@ import yaml
 
 
 logger = getLogger(__name__)
+DEREX_RUNNER_PROJECT_DIR = ".derex"
 
 
 class ProjectRunMode(Enum):
@@ -111,7 +112,7 @@ class Project:
     def _status_filepath(self, name: str) -> Path:
         """Return the full file path where a status for the project should be stored
         """
-        return self.root / name
+        return self.root / DEREX_RUNNER_PROJECT_DIR / name
 
     def __init__(self, path: Union[Path, str] = None):
         if not path:

--- a/derex/runner/project.py
+++ b/derex/runner/project.py
@@ -105,8 +105,11 @@ class Project:
         return None
 
     def _set_status(self, name: str, value: str):
-        """Persist a status in the project directory
+        """Persist a status in the project directory.
+        Each status will be written to a different file.
         """
+        if not self._status_filepath(name).parent.exists():
+            self._status_filepath(name).parent.mkdir()
         self._status_filepath(name).write_text(value)
 
     def _status_filepath(self, name: str) -> Path:

--- a/derex/runner/templates/local.yml.j2
+++ b/derex/runner/templates/local.yml.j2
@@ -3,7 +3,11 @@ version: "3.5"
 
 x-common:
   &common-conf
+  {% if project.runmode.name == "production" -%}
+  image: {{ project.image_tag }}
+  {% else -%}
   image: {{ project.requirements_image_tag }}
+  {% endif -%}
   tmpfs:
     - /tmp/
   networks:

--- a/derex/runner/templates/local.yml.j2
+++ b/derex/runner/templates/local.yml.j2
@@ -69,8 +69,16 @@ services:
 
   lms:
     <<: *common-conf
+    {% if project.runmode.value == "debug" -%}
     command:
       sh -c 'exec ./manage.py $${SERVICE_VARIANT} runserver --noreload 0:4700'
+    {% else -%}
+    command:
+      sh -c 'exec gunicorn --name $${SERVICE_VARIANT}
+        --bind=0.0.0.0:4700
+        --max-requests=1000
+        wsgi:application'
+    {% endif -%}
     ports:
       - 127.0.0.1:4700:4700
       - 127.0.0.1:4701:4701
@@ -78,8 +86,16 @@ services:
 
   cms:
     <<: *common-conf
+    {% if project.runmode.value == "debug" -%}
     command:
       sh -c 'exec ./manage.py $${SERVICE_VARIANT} runserver --noreload 0:4800'
+    {% else -%}
+    command:
+      sh -c 'exec gunicorn --name $${SERVICE_VARIANT}
+        --bind=0.0.0.0:4800
+        --max-requests=1000
+        wsgi:application'
+    {% endif -%}
     environment:
       <<: *cms-env
       DJANGO_SETTINGS_MODULE: cms.envs.{{ project.name }}.base
@@ -88,36 +104,6 @@ services:
       - 127.0.0.1:4801:4801
     container_name: {{ project.name }}_cms
 
-{% if final_image %}
-  lms_final:
-    <<: *common-conf
-    image: {{ final_image }}
-    command:
-      sh -c 'exec gunicorn --name $${SERVICE_VARIANT}
-        --bind=0.0.0.0:4710
-        --max-requests=1000
-        wsgi:application'
-    ports:
-      - 127.0.0.1:4710:4710
-      - 127.0.0.1:4711:4711
-    container_name: {{ project.name }}_lms_final
-
-  cms_final:
-    <<: *common-conf
-    image: {{ final_image }}
-    command:
-      sh -c 'exec gunicorn --name $${SERVICE_VARIANT}
-        --bind=0.0.0.0:4810
-        --max-requests=1000
-        wsgi:application'
-    environment:
-      <<: *cms-env
-      DJANGO_SETTINGS_MODULE: cms.envs.{{ project.name }}.base
-    ports:
-      - 127.0.0.1:4810:4810
-      - 127.0.0.1:4811:4811
-    container_name: {{ project.name }}_cms_final
-{% endif %}
   lms_worker:
     <<: *common-conf
     command:

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -7,7 +7,7 @@ flake8-import-order
 git+https://github.com/Abstract-Tech/pytest-black.git#egg=pytest-black
 git+https://github.com/Abstract-Tech/pytest-flake8.git#egg=pytest-flake8
 isort
-mypy
+mypy==0.761  # For some reason pip-compile is stuck to 0.740
 pip-tools
 pre-commit
 pytest

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,6 +19,7 @@ certifi==2019.9.11
 cffi==1.13.2
 cfgv==2.0.1               # via pre-commit
 chardet==3.0.4
+click-plugins==1.1.1
 click==7.0
 coverage==4.5.4
 cryptography==2.8
@@ -44,7 +45,7 @@ markupsafe==1.1.1
 mccabe==0.6.1             # via flake8
 more-itertools==7.2.0
 mypy-extensions==0.4.3    # via mypy
-mypy==0.740
+mypy==0.761
 nodeenv==1.3.3            # via pre-commit
 packaging==19.2           # via pytest, sphinx, tox
 paramiko==2.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,14 @@ def sys_argv(mocker):
 
 @pytest.fixture
 def testproj(workdir):
-    directory = TemporaryDirectory()
-    with open("a") as fh:
-        fh.write(f"project_name: testminimal")
-    return workdir(directory.name)
+    from derex.runner.utils import CONF_FILENAME
+
+    directory = TemporaryDirectory("-derex-project")
+    with open(f"{directory.name}/{CONF_FILENAME}", "w") as fh:
+        fh.write(f"project_name: testminimal\n")
+    result = workdir(directory.name)
+    # TemporaryDirectory will do its cleanup when it's garbage collected.
+    # We attach it to the workdir context manager so that it will be garbage collected
+    # together with it.
+    result._tmpdir = directory
+    return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import contextlib
 import os
@@ -36,3 +37,11 @@ def sys_argv(mocker):
                     raise
 
     return my_cm
+
+
+@pytest.fixture
+def testproj(workdir):
+    directory = TemporaryDirectory()
+    with open("a") as fh:
+        fh.write(f"project_name: testminimal")
+    return workdir(directory.name)

--- a/tests/fixtures/tests/Caddyfile
+++ b/tests/fixtures/tests/Caddyfile
@@ -1,13 +1,13 @@
 https://lms.edx.localhost {
     tls self_signed
-    proxy / lms_final:4710 {
+    proxy / lms:4710 {
         transparent
     }
 }
 
 https://cms.edx.localhost {
     tls self_signed
-    proxy / cms_final:4810 {
+    proxy / cms:4810 {
         transparent
     }
 }

--- a/tests/fixtures/tests/derex.config.yaml
+++ b/tests/fixtures/tests/derex.config.yaml
@@ -1,2 +1,3 @@
 ---
 project_name: tests
+default_runmode: production

--- a/tests/fixtures/tests/docker-compose.yml
+++ b/tests/fixtures/tests/docker-compose.yml
@@ -1,14 +1,6 @@
 version: "3.5"
 
 services:
-  cms:
-    command: "true"
-  lms:
-    command: "true"
-  lms_final:
-    ports: []
-  cms_final:
-    ports: []
   webserver:
     image: abiosoft/caddy
     entrypoint: caddy --conf /etc/Caddyfile --log stdout
@@ -21,7 +13,7 @@ services:
     volumes:
       - ../Caddyfile:/etc/Caddyfile:ro
     links:
-      - lms_final
-      - cms_final
+      - lms
+      - cms
     networks:
       - derex

--- a/tests/test_derex.py
+++ b/tests/test_derex.py
@@ -69,7 +69,11 @@ def test_derex_runmode(testproj):
 
         result = runner.invoke(derex, ["runmode", "production"])
         assert result.exit_code == 0, result.output
-        assert result.stderr_bytes == b""
+        assert "debug → production" in result.stderr_bytes.decode("utf8")
+
+        result = runner.invoke(derex, ["runmode", "production"])
+        assert result.exit_code == 0, result.output
+        assert "already production" in result.stderr_bytes.decode("utf8")
 
         result = runner.invoke(derex, ["runmode"])
         assert result.exit_code == 0, result.output

--- a/tests/test_derex.py
+++ b/tests/test_derex.py
@@ -52,6 +52,25 @@ def test_derex_reset_mysql(sys_argv, mocker, workdir):
     assert result.exit_code == 0
 
 
+def test_derex_runmode(testproj):
+    from derex.runner.cli import derex
+
+    with testproj:
+        result = runner.invoke(derex, ["runmode"])
+        assert result.exit_code == 0, result.output
+        assert result.output == "debug\n"
+
+        result = runner.invoke(derex, ["runmode", "aaa"])
+        assert result.exit_code == 2, result.output
+
+        result = runner.invoke(derex, ["runmode", "production"])
+        assert result.exit_code == 0, result.output
+
+        result = runner.invoke(derex, ["runmode"])
+        assert result.exit_code == 0, result.output
+        assert result.output == "production\n"
+
+
 def assert_result_ok(result):
     """Makes sure the click script exited on purpose, and not by accident
     because of an exception.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -39,5 +39,20 @@ def test_minimal_project(workdir):
 
 
 def test_runmode(testproj):
+    from derex.runner.project import Project
+    from derex.runner.project import ProjectRunMode
+    from derex.runner.utils import CONF_FILENAME
+
     with testproj:
-        pass
+        # If no default is specified, the value should be debug
+        assert Project().runmode == ProjectRunMode.debug
+
+        # If a default value is specified, it should be picked up
+        with (Path(testproj._tmpdir.name) / CONF_FILENAME).open("a") as fh:
+            fh.write("default_runmode: production\n")
+        assert Project().runmode == ProjectRunMode.production
+
+        Project().runmode = ProjectRunMode.production
+        # Runmode changes should be persisted in the project directory
+        # and picked up by a second Project instance
+        assert Project().runmode == ProjectRunMode.production

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -36,3 +36,8 @@ def test_minimal_project(workdir):
     assert project.requirements_image_tag == project.image_tag
     assert project.themes_image_tag == project.image_tag
     assert project.themes_image_tag == project.base_image
+
+
+def test_runmode(testproj):
+    with testproj:
+        pass


### PR DESCRIPTION
This PR introduces a change in how derex treats `runserver` vs `gunicorn` containers: instead of having both defined we only have `lms` and `cms`. They will use one command or the other according to the project `runmode`.

The `runmode` is an attribute persisted in the project. A default `runmode` can be specified in the project config.

