### PR TITLE
Fix registry bug

### DIFF
--- a/derex/runner/compose_utils.py
+++ b/derex/runner/compose_utils.py
@@ -63,17 +63,19 @@ def get_compose_options(
     plugin_manager = setup_plugin_manager()
     registry = Registry()
     if project:
-        for opts in plugin_manager.hook.local_compose_options(project=project):
-            registry.add(
-                key=opts["name"], value=opts["options"], location=opts["priority"]
-            )
+        to_add = [
+            (opts["name"], opts["options"], opts["priority"])
+            for opts in plugin_manager.hook.local_compose_options(project=project)
+        ]
+        registry.add_list(to_add)
     else:
         ensure_volumes_present()
-        for opts in plugin_manager.hook.compose_options():
-            if opts["variant"] == variant:
-                registry.add(
-                    key=opts["name"], value=opts["options"], location=opts["priority"]
-                )
+        to_add = [
+            (opts["name"], opts["options"], opts["priority"])
+            for opts in plugin_manager.hook.compose_options()
+            if opts["variant"] == variant
+        ]
+        registry.add_list(to_add)
     settings = [el for lst in registry for el in lst]
     return ["docker-compose"] + settings + args
 

--- a/derex/runner/plugins.py
+++ b/derex/runner/plugins.py
@@ -187,3 +187,17 @@ class Registry(object):
                 'must start with a ">" or "<".' % location
             )
         self.register(value, key, priority)
+
+    def add_list(self, to_add):
+        to_add_later = []
+        for el in to_add:
+            try:
+                self.add(*el)
+            except ValueError:
+                to_add_later.append(el)
+        for _ in range(3):  # Try for three rounds (arbitrarily chosen)
+            for el in to_add_later:
+                try:
+                    self.add(*el)
+                except ValueError:
+                    continue

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,20 @@
 from itertools import permutations
 
+import pytest
+
+
+def test_registry_exception():
+    from derex.runner.plugins import Registry
+
+    registry = Registry()
+    registry.add("one", "one", "badlocation")
+
+    with pytest.raises(ValueError):
+        registry.add("one", "one", "badlocation")
+
+    with pytest.raises(ValueError):
+        registry.deregister("doesnotexist")
+
 
 def test_registry_basic():
     from derex.runner.plugins import Registry

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -12,4 +12,10 @@ def test_registry_basic():
     )
 
     assert registry["last"] == "I should be last"
+    assert registry[-1] == "I should be last"
     assert registry["first"] == "I should be first"
+    assert registry[0] == "I should be first"
+
+    # Now move the last to the beginning, just to prove we can
+    registry.add("last", "I should be last", "_begin")
+    assert registry[0] == "I should be last"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,3 +1,6 @@
+from itertools import permutations
+
+
 def test_registry_basic():
     from derex.runner.plugins import Registry
 
@@ -19,3 +22,24 @@ def test_registry_basic():
     # Now move the last to the beginning, just to prove we can
     registry.add("last", "I should be last", "_begin")
     assert registry[0] == "I should be last"
+
+
+def test_registry_add_list():
+    from derex.runner.plugins import Registry
+
+    to_add = [
+        ("last", "I should be last", "_end"),
+        ("first", "I should be first", "_begin"),
+        ("in-between-1", "I should be the first in between first and last", ">first"),
+        ("in-between-2", "I should be the second in between first and last", "<last"),
+    ]
+    # Verify that it always works, no matter how the list is sorted
+    for variant in permutations(to_add):
+        registry = Registry()
+        registry.add_list(variant)
+        assert tuple(registry) == (
+            "I should be first",
+            "I should be the first in between first and last",
+            "I should be the second in between first and last",
+            "I should be last",
+        )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,15 @@
+def test_registry_basic():
+    from derex.runner.plugins import Registry
+
+    registry = Registry()
+    registry.add("last", "I should be last", "_end")
+    registry.add("first", "I should be first", "_begin")
+    registry.add(
+        "in-between-1", "I should be the first in between first and last", ">first"
+    )
+    registry.add(
+        "in-between-2", "I should be the second in between first and last", "<last"
+    )
+
+    assert registry["last"] == "I should be last"
+    assert registry["first"] == "I should be first"


### PR DESCRIPTION
The order plugins are invoked by `plugin_manager.hook` is not guaranteed.

Therefore we need to be prepared for any order.

This PR changes the code in the registry adding a `add_list` method, that will try up to three rounds to get the right sorting.