### PR TITLE
Add wget to the base image.

### DIFF
--- a/docker-definition/Dockerfile
+++ b/docker-definition/Dockerfile
@@ -35,7 +35,8 @@ RUN --mount=type=cache,target=/var/cache/apk apk add \
     libxslt \
     mariadb-connector-c \
     sqlite \
-    xmlsec
+    xmlsec \
+    wget
 
 COPY patch_ldconfig_to_fix_shapely.sh /tmp/patch_ldconfig_to_fix_shapely.sh
 


### PR DESCRIPTION
The Busybox wget implementation causes annoying StopIteration errors
from gunicorn. The regular one does not. We trade 500 kb more in the
image for usability wrt the gunicorn logs.