### PR TITLE
Support openssl pre 1.1

### DIFF
--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -13,6 +13,7 @@ stages:
           - script: |
               set -ex
               set -o pipefail
+              pip3 --cache-dir $(Pipeline.Workspace)/.cache/pip install scrypt
               cd tests
               pytest -m "not slowtest" --ignore-docstrings |grep -v codecoveragetool=Cobertura
             displayName: "Run python tests"

--- a/derex/runner/cli/__init__.py
+++ b/derex/runner/cli/__init__.py
@@ -242,16 +242,7 @@ def update_minio(old_key: str):
     script += f' && export MINIO_ACCESS_KEY_OLD="$MINIO_ACCESS_KEY" MINIO_SECRET_KEY_OLD="{old_key}"'
     expected_string = "Rotation complete, please make sure to unset MINIO_ACCESS_KEY_OLD and MINIO_SECRET_KEY_OLD envs"
     script += f" && expect -c 'spawn /usr/bin/minio server /data; expect \"{expected_string}\" {{ close; exit 0 }}'"
-    args = [
-        "run",
-        "--rm",
-        "--entrypoint",
-        "/bin/sh",
-        "-T",
-        "minio",
-        "-c",
-        script,
-    ]
+    args = ["run", "--rm", "--entrypoint", "/bin/sh", "-T", "minio", "-c", script]
     run_compose(args, exit_afterwards=True)
     click.echo(f"Minio server rekeying finished")
 

--- a/derex/runner/cli/mongodb.py
+++ b/derex/runner/cli/mongodb.py
@@ -77,9 +77,7 @@ def list_mongodb(project: Optional[Project], db_name: str):
 @mongodb.command("copy")
 @click.argument("source_db_name", type=str, required=True)
 @click.argument("destination_db_name", type=str)
-@click.option(
-    "--drop", is_flag=True, default=False, help="Drop the source database",
-)
+@click.option("--drop", is_flag=True, default=False, help="Drop the source database")
 @click.pass_obj
 def copy_mongodb(
     project: Optional[Project],

--- a/derex/runner/cli/mysql.py
+++ b/derex/runner/cli/mysql.py
@@ -150,7 +150,7 @@ def show_users_cmd():
 @click.argument("destination_db_name", type=str)
 @click.pass_obj
 def copy_database_cmd(
-    project: Optional[Project], source_db_name: str, destination_db_name: Optional[str],
+    project: Optional[Project], source_db_name: str, destination_db_name: Optional[str]
 ):
     """
     Copy an existing mysql database. If no destination database is given it defaults

--- a/derex/runner/secrets.py
+++ b/derex/runner/secrets.py
@@ -25,7 +25,11 @@ def scrypt_hash_stdlib(main_secret: str, name: str) -> bytes:
     from hashlib import scrypt
 
     return scrypt(
-        main_secret.encode("utf-8"), salt=name.encode("utf-8"), n=2, r=8, p=1  # type: ignore
+        main_secret.encode("utf-8"),
+        salt=name.encode("utf-8"),
+        n=2,
+        r=8,
+        p=1,  # type: ignore
     )
 
 

--- a/derex/runner/secrets.py
+++ b/derex/runner/secrets.py
@@ -3,7 +3,6 @@
 from base64 import b64encode
 from collections import Counter
 from enum import Enum
-from hashlib import scrypt
 from pathlib import Path
 from typing import Any
 from typing import Optional
@@ -20,6 +19,32 @@ DEREX_MAIN_SECRET_MAX_SIZE = 1024
 DEREX_MAIN_SECRET_MIN_SIZE = 8
 DEREX_MAIN_SECRET_MIN_ENTROPY = 128
 DEREX_MAIN_SECRET_PATH = "/etc/derex/main_secret"
+
+
+def scrypt_hash_stdlib(main_secret: str, name: str) -> bytes:
+    from hashlib import scrypt
+
+    return scrypt(
+        main_secret.encode("utf-8"), salt=name.encode("utf-8"), n=2, r=8, p=1  # type: ignore
+    )
+
+
+def scrypt_hash_addon(main_secret: str, name: str) -> bytes:
+    """
+    """
+    from scrypt import scrypt
+
+    return scrypt.hash(main_secret.encode("utf-8"), name.encode("utf-8"), N=2, r=8, p=1)
+
+
+try:
+    from hashlib import scrypt as _
+
+    scrypt_hash = scrypt_hash_stdlib
+except ImportError:
+    from scrypt import scrypt as _  # type:ignore  # noqa
+
+    scrypt_hash = scrypt_hash_addon
 
 
 class DerexSecrets(Enum):
@@ -68,13 +93,7 @@ def _get_master_secret() -> Optional[str]:
 def get_secret(secret: DerexSecrets) -> str:
     """Derive a secret using the master secret and the provided name.
     """
-    binary_secret = scrypt(
-        MASTER_SECRET.encode("utf-8"),
-        salt=secret.name.encode("utf-8"),
-        n=2,
-        r=8,
-        p=1,  # type: ignore
-    )
+    binary_secret = scrypt_hash(MASTER_SECRET, secret.name)
     # Pad the binary string so that its length is a multiple of 3
     # This will make sure its base64 representation is equals-free
     new_length = len(binary_secret) + (3 - len(binary_secret) % 3)

--- a/derex/runner/settings/derex/staticfiles.py
+++ b/derex/runner/settings/derex/staticfiles.py
@@ -2,11 +2,10 @@ from path import Path
 
 
 STATIC_ROOT_BASE = "/openedx/staticfiles"
-STATIC_ROOT = {
-    "lms": Path(STATIC_ROOT_BASE),
-    "cms": Path(STATIC_ROOT_BASE) / "studio",
-}[SERVICE_VARIANT]
-STATIC_URL = {"lms": "/static/", "cms": "/static/studio/",}[SERVICE_VARIANT]
+STATIC_ROOT = {"lms": Path(STATIC_ROOT_BASE), "cms": Path(STATIC_ROOT_BASE) / "studio"}[
+    SERVICE_VARIANT
+]
+STATIC_URL = "/static/"
 
 WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 COMPREHENSIVE_THEME_DIRS.append(Path("/openedx/themes"))

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,12 +6,12 @@
 #
 alabaster==0.7.12         # via -r requirements_doc.txt, sphinx
 appdirs==1.4.3            # via -r requirements.txt, black, virtualenv
-astroid==2.4.0            # via -r requirements_doc.txt, sphinx-autoapi
+astroid==2.4.1            # via -r requirements_doc.txt, sphinx-autoapi
 attrs==19.3.0             # via -r requirements.txt, black, jsonschema, pytest
 babel==2.8.0              # via -r requirements_doc.txt, sphinx
 bcrypt==3.1.7             # via -r requirements.txt, paramiko
 black==19.3b0             # via -r requirements_dev.in, pytest-black
-bleach==3.1.4             # via readme-renderer
+bleach==3.1.5             # via readme-renderer
 bump2version==1.0.0       # via -r requirements_dev.in
 cached-property==1.5.1    # via -r requirements.txt, docker-compose
 certifi==2020.4.5.1       # via -r requirements.txt, -r requirements_doc.txt, requests
@@ -40,7 +40,7 @@ isort==4.3.21             # via -r requirements_dev.in
 jeepney==0.4.3            # via keyring, secretstorage
 jinja2==2.11.2            # via -r requirements.txt, -r requirements_doc.txt, sphinx, sphinx-autoapi
 jsonschema==3.2.0         # via -r requirements.txt, docker-compose
-keyring==21.2.0           # via twine
+keyring==21.2.1           # via twine
 lazy-object-proxy==1.4.3  # via -r requirements_doc.txt, astroid
 markupsafe==1.1.1         # via -r requirements.txt, -r requirements_doc.txt, jinja2
 mccabe==0.6.1             # via flake8
@@ -48,10 +48,10 @@ more-itertools==8.2.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
 mypy==0.761               # via -r requirements_dev.in
 nodeenv==1.3.5            # via pre-commit
-packaging==20.3           # via -r requirements_doc.txt, pytest, sphinx, tox
+packaging==20.3           # via -r requirements_doc.txt, bleach, pytest, sphinx, tox
 paramiko==2.7.1           # via -r requirements.txt, docker
 pathtools==0.1.2          # via watchdog
-pip-tools==5.1.0          # via -r requirements_dev.in
+pip-tools==5.1.2          # via -r requirements_dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements.txt, pytest, tox
 pre-commit==2.3.0         # via -r requirements_dev.in
@@ -91,14 +91,14 @@ sphinxcontrib-serializinghtml==1.1.4  # via -r requirements_doc.txt, sphinx
 tabulate==0.8.7           # via -r requirements.txt
 texttable==1.6.2          # via -r requirements.txt, docker-compose
 toml==0.10.0              # via black, pre-commit, tox
-tox==3.14.6               # via -r requirements_dev.in
-tqdm==4.45.0              # via twine
+tox==3.15.0               # via -r requirements_dev.in
+tqdm==4.46.0              # via twine
 twine==3.1.1              # via -r requirements_dev.in
 typed-ast==1.4.1          # via -r requirements_doc.txt, astroid, mypy
 typing-extensions==3.7.4.2  # via mypy
 unidecode==1.1.1          # via -r requirements_doc.txt, sphinx-autoapi
 urllib3==1.25.9           # via -r requirements.txt, -r requirements_doc.txt, requests
-virtualenv==20.0.18       # via pre-commit, tox
+virtualenv==20.0.20       # via pre-commit, tox
 watchdog==0.10.2          # via -r requirements_dev.in
 wcwidth==0.1.9            # via pytest
 webencodings==0.5.1       # via bleach

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -5,7 +5,7 @@
 #    pip-compile requirements_doc.in
 #
 alabaster==0.7.12         # via sphinx
-astroid==2.4.0            # via sphinx-autoapi
+astroid==2.4.1            # via sphinx-autoapi
 babel==2.8.0              # via sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -89,6 +89,18 @@ def test_derived_secret_no_scrypt_available(no_scrypt):
     derex.runner.secrets.get_secret(FooSecrets.foo)
 
 
+try:
+    from hashlib import scrypt
+    from scrypt import scrypt  # type:ignore  # noqa
+
+    only_one_scrypt_implementations = False
+except ImportError:
+    only_one_scrypt_implementations = True
+
+
+@pytest.mark.skipif(
+    only_one_scrypt_implementations, reason="We don't have both openssl>=1.1 and scrypt"
+)
 def test_derived_secret_no_scrypt_same_result_as_with_scrypt():
     from derex.runner.secrets import scrypt_hash_stdlib
     from derex.runner.secrets import scrypt_hash_addon

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -105,10 +105,7 @@ def test_derived_secret_no_scrypt_same_result_as_with_scrypt():
     from derex.runner.secrets import scrypt_hash_stdlib
     from derex.runner.secrets import scrypt_hash_addon
 
-    TEST_CASES = [
-        ("aaa", "bbb"),
-        ("The master secret", "the service"),
-    ]
+    TEST_CASES = [("aaa", "bbb"), ("The master secret", "the service")]
     for a, b in TEST_CASES:
         assert scrypt_hash_addon(a, b) == scrypt_hash_stdlib(a, b)
 


### PR DESCRIPTION
With the introduction of master secret and per-service secret we started depending on `hashlib.scrypt` from the python standard library.

It's not be present in systems with an openssl version lower than 1.1.

To support older OpenSSL versions this PR allows users to `pip install scrypt` (manually) and still be able to use derex.