### PR TITLE
Use regular expression to remove .derex only from the end of host names

### DIFF
--- a/derex/runner/docker_utils.py
+++ b/derex/runner/docker_utils.py
@@ -190,7 +190,7 @@ def get_running_containers() -> Dict:
 
 def get_exposed_container_names() -> List:
     result = []
-    for name, container in get_running_containers().items():
+    for container in get_running_containers().values():
         names = container["NetworkSettings"]["Networks"]["derex"]["Aliases"]
         matching_names = list(filter(lambda el: el.endswith("localhost.derex"), names))
         if matching_names:
@@ -199,7 +199,9 @@ def get_exposed_container_names() -> List:
             )
             result.append(
                 tuple(
-                    map(lambda el: "http://" + el.replace(".derex", ""), matching_names)
+                    map(
+                        lambda el: "http://" + re.sub(".derex$", "", el), matching_names
+                    )
                 )
             )
     return result

--- a/tests/test_derex.py
+++ b/tests/test_derex.py
@@ -102,6 +102,38 @@ def test_derex_cli_group_no_containers_running(monkeypatch):
     )
 
 
+def test_get_exposed_container_names(monkeypatch):
+    from derex.runner import docker_utils
+
+    response = {
+        "derex_services_minio_1": {
+            "NetworkSettings": {
+                "Networks": {
+                    "derex": {
+                        "Aliases": ["minio.localhost.derex"],
+                        "IPAddress": "172.11.0.12",
+                    }
+                }
+            }
+        },
+        "derex-themes_lms_1": {
+            "NetworkSettings": {
+                "Networks": {
+                    "derex": {
+                        "Aliases": ["studio.derex-themes.localhost.derex"],
+                        "IPAddress": "172.11.0.12",
+                    }
+                }
+            }
+        },
+    }
+    monkeypatch.setattr(docker_utils, "get_running_containers", lambda: response)
+    result = docker_utils.get_exposed_container_names()
+
+    assert result[0][0] == "http://minio.localhost"
+    assert result[1][0] == "http://studio.derex-themes.localhost"
+
+
 def test_derex_cli_group_one_container_running(monkeypatch):
     from derex.runner import docker_utils
 


### PR DESCRIPTION
A bad substitution was causing what should have been `studio.derex-themes.localhost` to be `studio-themes.localhost`