### PR TITLE
Fix mongodb authentication error and filesystem root

### DIFF
--- a/derex/runner/settings/derex/mongo.py
+++ b/derex/runner/settings/derex/mongo.py
@@ -1,14 +1,28 @@
+try:
+    from pathlib import Path
+except ImportError:
+    from path import Path
+
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 
 
 MONGODB_HOST = "mongodb"
 MONGODB_DB_NAME = os.environ["MONGODB_DB_NAME"]
+DOC_STORE_CONFIG = {
+    "host": MONGODB_HOST,
+    "db": MONGODB_DB_NAME,
+    "user": None,
+    "password": None,
+}
 CONTENTSTORE = {
     "ENGINE": "xmodule.contentstore.mongo.MongoContentStore",
-    "DOC_STORE_CONFIG": {"host": MONGODB_HOST, "db": MONGODB_DB_NAME},
+    "DOC_STORE_CONFIG": DOC_STORE_CONFIG,
 }
-DOC_STORE_CONFIG = {"host": MONGODB_HOST, "db": MONGODB_DB_NAME}
-update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+update_module_store_settings(
+    MODULESTORE,
+    doc_store_settings=DOC_STORE_CONFIG,
+    module_store_options={"fs_root": Path("/openedx/data"),},
+)
 
 # This is needed for the Sysadmin dashboard "Git Logs" tab
 MONGODB_LOG = {


### PR DESCRIPTION
This PR fixes mongodb authentication connection error.

To replicate the problem just create a course in studio and try to look at it in the LMS. You should be greeted with something like:

OperationFailure at /courses/course-v1:Test+Test+TEst/courseware/8794b75976ee402a88cb7c530da8e7d1/3a4d58a0b5ee454e8f40df9d4d693e4a/1

`{'code': 18, 'errmsg': 'Authentication failed.', 'ok': 0.0}`