### PR TITLE
Add timeout to lms docker-compose config

### DIFF
--- a/derex/runner/templates/docker-compose-project.yml.j2
+++ b/derex/runner/templates/docker-compose-project.yml.j2
@@ -92,6 +92,7 @@ services:
         --worker-class gevent
         --worker-tmp-dir /dev/shm
         --log-file=-
+        --timeout 300
         wsgi:application'
     healthcheck:
       test: ["CMD", "wget", "localhost:80/heartbeat", "-q", "-O", "/dev/null"]


### PR DESCRIPTION
Since derex.runner supports Lilac release we started observing error logs in the lms container:

> [2022-07-06 10:16:01 +0000] [1] [WARNING] Worker with pid 5099 was terminated due to signal 9
> [2022-07-06 10:16:01 +0000] [1] [WARNING] Worker with pid 5101 was terminated due to signal 9
> [2022-07-06 10:16:01 +0000] [5294] [INFO] Booting worker with pid: 5294
> [2022-07-06 10:16:01 +0000] [1] [WARNING] Worker with pid 5100 was terminated due to signal 9
> [2022-07-06 10:16:01 +0000] [5295] [INFO] Booting worker with pid: 5295
> [2022-07-06 10:16:01 +0000] [5296] [INFO] Booting worker with pid: 5296
> [2022-07-06 10:16:31 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:5294)
> [2022-07-06 10:16:31 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:5295)
> [2022-07-06 10:16:31 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:5296)